### PR TITLE
Document new Docker compose setup

### DIFF
--- a/docs/02-Installation/01-Server/04-docker.md
+++ b/docs/02-Installation/01-Server/04-docker.md
@@ -18,7 +18,8 @@ keywords:
 
 OpenUEM can be tested using Docker containers that are hosted in [Docker Hub](https://hub.docker.com/u/openuem)
 
-You can use [docker compose](https://docs.docker.com/compose/) to install all OpenUEM components in a single machine following these steps:
+You can use [docker compose](https://docs.docker.com/compose/) to install all OpenUEM components in a single machine
+following these steps:
 
 ## 1. Get the docker-compose file
 
@@ -33,201 +34,151 @@ git clone https://github.com/open-uem/openuem-docker
 Use the file named `.env-example` file to create a `.env` file
 
 :::note
-The file must be named .env without extension and with a dot before the env word as required by Docker to read the environment variables
+The file must be named .env without extension and with a dot before the env word as required by Docker to read the
+environment variables
 :::
 
-In the `.env` file, edit the environment variables that docker compose will use to build and get the containers up and running.
-
-:::warning
-You should set the Postgres database user and password in the `init.sh` file inside the `postgres\build` as defaults used are dummy, unsafe values
-that should not be used in production
-
-```
-psql -v ON_ERROR_STOP=1 --username "postgres" <<-EOSQL
-  CREATE DATABASE openuem;
-  CREATE USER **YOUR_USER** WITH ENCRYPTED PASSWORD '**YOUR PASSWORD**';
-  GRANT ALL PRIVILEGES ON DATABASE openuem TO **YOUR_USER**;
-  ALTER DATABASE openuem OWNER TO **YOUR_USER**;
-EOSQL
-```
-
-**Then you must change the DATABASE_URL** in the .env file to use the username and password accordingly
-
-:::
-
-Here are the possible environment variables that can appear in the .env file.
-
-| Name                    | Description                                                                                                                         | Optional | Example value                                           |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------- |
-| SERVER_NAME             | The name of the server where the console is hosted                                                                                  | no       | server.example.com                                      |
-| POSTGRES_PORT           | The port number where the database service should be found                                                                          | no       | 5432                                                    |
-| DATABASE_URL            | The database url in format postgres://user:password@openuem-db-1:port/openuem                                                       | no       | postgres://test:test@openuem-db-1:5432/openuem          |
-| ORGNAME                 | Your organization's name                                                                                                            | no       | OpenUEM                                                 |
-| ORGPROVINCE             | Your organization's province                                                                                                        | yes      | Valladolid                                              |
-| ORGLOCALITY             | Your organization's locality                                                                                                        | yes      | Valladolid                                              |
-| ORGADDRESS              | Your organization's address                                                                                                         | yes      | My org's address                                        |
-| COUNTRY                 | Your organization's country                                                                                                         | no       | ES                                                      |
-| OCSP_PORT               | The port used by the OCSP responder                                                                                                 | no       | 8000                                                    |
-| NATS_SERVER             | The domain name used by the NATS server                                                                                             | no       | The value of SERVER_NAME                                |
-| NATS_PORT               | The port used by the NATS server                                                                                                    | no       | 4433                                                    |
-| NATS_SERVERS            | The NATS service url                                                                                                                | no       | server.example.com:4433                                 |
-| REVERSE_PROXY_SERVER    | If you want to use a reverse proxy, set the domain name that you want to use to visit the console, **use an empty value otherwise** | no       | console.example.com or **use an empty value otherwise** |
-| REVERSE_PROXY_AUTH_PORT | If you want to use a reverse proxy, set the port that will be used to answer for auth, **use an empty value otherwise**             | no       | 1340 or **use an empty value otherwise**                |
-| OCSP                    | The URL for the OCSP responder service                                                                                              | no       | http://server.example.com:8000                          |
-| DOMAIN                  | Your DNS domain                                                                                                                     | no       | example.com                                             |
-| CONSOLE_PORT            | The port used by the console                                                                                                        | no       | 1323                                                    |
-| AUTH_PORT               | The port used by the auth server                                                                                                    | no       | 1324                                                    |
-| JWT_KEY                 | The key used to encrypt JWT tokens for user registration                                                                            | no       | averylongsecret                                         |
-| TZ                      | The timezone used by OpenUEM containers                                                                                             | yes      | Europe/Madrid                                           |
-
-server.example.com should be resolved by your DNS service if you want remote agents to be able to contact OpenUEM components.
-
-:::tip
-If you don't have a DNS you can use extra_hosts in the docker_compose.yml to add entries for the containers as if you were using /etc/hosts
-
-Reference: https://docs.docker.com/reference/compose-file/build/#extra_hosts
-
-![Extra hosts](/img/docker/extra_hosts.png)
-:::
+In the `.env` file, edit the environment variables that docker compose will use to build and get the containers up and
+running. The `.env-example` you just copied already sets up a working demo instance of OpenUEM on the `openuem.example`
+domain. If you
+want to simply try out OpenUEM you can just use it as-is. If you want to setup a production system or use your own
+domain and information, you can customize the `.env` just created.
 
 :::danger
 It's strongly recommended to change the JWT key with a random 32 characters long string
 :::
 
+Here are the possible environment variables that can appear in the .env file.
+
+| Name                       | Description                                                                                                                         | Required | Example value                                                     |
+|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------|----------|-------------------------------------------------------------------|
+| DATABASE_DB_NAME           | Name of the postgres database used (will be created automatically on first start)                                                   | yes      | openuem                                                           |
+| DATABASE_PORT              | Public port exposed by the database service                                                                                         | yes      | 5432                                                              |
+| DATABASE_USER              | Username used to connect to the database (will be created automatically on first start)                                             | yes      | openuem                                                           |
+| DATABASE_PASSWORD          | Password used to connect to the database (will be set automatically on first start)                                                 | yes      | supersecret-dbpassword                                            |
+| OPENUEM_DATABASE_URL       | The database url in format postgres://user:password@openuem-db-1:port/openuem                                                       | yes      | postgres://openuem:supersecret-dbpassword@openuem-db:5432/openuem |
+| OPENUEM_ORGNAME            | Your organization's name                                                                                                            | yes      | OpenUEM                                                           |
+| OPENUEM_ORGPROVINCE        | Your organization's province                                                                                                        | no       | Valladolid                                                        |
+| OPENUEM_ORGLOCALITY        | Your organization's locality                                                                                                        | no       | Valladolid                                                        |
+| OPENUEM_ORGADDRESS         | Your organization's address                                                                                                         | no       | My org's address                                                  |
+| OPENUEM_COUNTRY            | Your organization's country                                                                                                         | yes      | ES                                                                |          |                                                         |
+| OPENUEM_DOMAIN             | Your DNS domain. All other services should resolve to either this domain or a subdomain.                                            | yes      | openuem.example                                                   |
+| TZ                         | The timezone used by OpenUEM containers                                                                                             | no       | Europe/Madrid                                                     |
+| REVERSE_PROXY_HOST         | If you want to use a reverse proxy, set the domain name that you want to use to visit the console, **use an empty value otherwise** | yes      | console.openuem.example or **use an empty value otherwise**       |
+| REVERSE_PROXY_CONSOLE_PORT | If you want to use a reverse proxy, set the port that will be used to serve the console web ui, **use an empty value otherwise**    | yes      | 443 or **use an empty value otherwise**                           |
+| REVERSE_PROXY_AUTH_PORT    | If you want to use a reverse proxy, set the port that will be used to answer for auth, **use an empty value otherwise**             | yes      | 4443 or **use an empty value otherwise**                          |
+| NATS_HOST                  | The domain name used by the NATS server                                                                                             | yes      | nats.openuem.example                                              |
+| NATS_PORT                  | The port used by the NATS server                                                                                                    | yes      | 4433                                                              |
+| OCSP_URL                   | The URL for the OCSP responder service                                                                                              | yes      | http://ocsp.openuem.example:8000                                  |
+| OCSP_HOST                  | The host domain for the OCSP responder service                                                                                      | yes      | ocsp.openuem.example                                              |
+| OCSP_PORT                  | The port used by the OCSP responder                                                                                                 | yes      | 8000                                                              |
+| CONSOLE_HOST               | The name of the server where the console is hosted                                                                                  | yes      | console.openuem.example                                           |
+| CONSOLE_PORT               | The port used by the console                                                                                                        | yes      | 1323                                                              |
+| CONSOLE_AUTH_PORT          | The port used by the auth server                                                                                                    | yes      | 1324                                                              |
+| CONSOLE_JWT_KEY            | The key used to encrypt JWT tokens for user registration                                                                            | yes      | averylongsecret                                                   |
+| OPENUEM_NATS_SERVERS       | List of all NATS servers that will be used by many OpenUEM components. Normally this will be $NATS_HOST:$NATS_PORT                  | yes      | nats.openuem.example:4433                                         |
+
+It is possible to only use one domain for all services, but `CONSOLE_HOST`, `OPENUEM_NATS_SERVERS` and `NATS_HOST`
+should be resolved by your DNS service. If you are just locally deploying a demo instance and don't have access to a
+DNS, you can override your devices `hosts` configuration and allow local domain resolution.
+
+- On Linux: this configuration can be found under `/etc/hosts`. Add the line `{YOUR_LOCAL_IP} *.{OPENUEM_DOMAIN}`
+- On Windows: the configuration can be found under `C:\Windows\System32\drivers\etc\hosts`. Add the line
+  `{YOUR_LOCAL_IP} *.{OPENUEM_DOMAIN}`
+
+You have to replace `{YOUR_LOCAL_IP}` and `{OPENUEM_DOMAIN}` with their respective values. It is **important** that you
+use your **local ip address** (e.g. 192.168.1.43) **instead** of localhost or 127.0.0.1. Docker will copy these
+overrides into the containers on start. If you use localhost, each container will only try to connect to itself, making
+proper domain resolution impossible.
+
+:::warning
+The method of editing the `hosts` file should only be used for a local demo instance
+:::
+
 ## 3. Use a reverse proxy (Optional)
 
 You can run OpenUEM behind a reverse proxy. Caddy can be used and is supported for this deployment with docker compose.
-
-First you must set the REVERSE_PROXY_SERVER and REVERSE_PROXY_AUTH_PORT env variables in the .env file and the REVERSE_PROXY_SERVER domain must be resolved by a DNS server.
-
-Second you must uncomment these lines and watch that the right indentation is set:
-
-```
-  # caddy:
-  #   image: caddy:latest
-  #   restart: always
-  #   profiles: ["caddy"]
-  #   env_file:
-  #     - .env
-  #   ports:
-  #     - "443:443"
-  #     - $REVERSE_PROXY_AUTH_PORT:$REVERSE_PROXY_AUTH_PORT
-  #   volumes:
-  #     - "./caddy/Caddyfile:/etc/caddy/Caddyfile"
-  #     - "./certificates/ca/ca.cer:/etc/caddy/ca.cer"
-  #     - "./certificates/console/proxy.cer:/etc/caddy/proxy.cer"
-  #     - "./certificates/console/proxy.key:/etc/caddy/proxy.key"
-  #     - caddy_data:/data
-  #     - caddy_config:/config
-
-
-  # caddy_data:
-  #   driver: local
-  # caddy_config:
-  #   driver: local
-```
+If you decide to use Caddy as a reverse proxy, set the variables prefixed `REVERSE_PROXY` in the `.env` file (see the
+table above). Remember that the hosts / domains you set have to be resolvable by a DNS.
 
 ## 4. Launch docker compose command
 
 Where the compose.yaml file and the .env files are located, launch OpenUEM with the following commands:
 
+Without Caddy support:
+
+```bash
+docker compose -d --build
+```
+
+With Caddy support:
+
 ```(bash)
-docker compose --profile init up -d --build
+docker compose -f compose-caddy.yml up -d --build
 ```
 
-Once we run that command, we should see that the database service is healthy and ready:
-
-```
- ✔ Network openuem_default  Created
- ✔ Volume "openuem_pgdata"  Created
- ✔ Container openuem-db-1   Healthy
- ✔ Container openuem-certs  Started
-```
-
-Also, we should see that a certificates folder has been created containing all the required certificates:
+On first start all the certificates are generated in the certificates folder:
 
 ![Certificates folder](/img/docker/certificates_folder.png)
 
 :::warning
-The generation of certificates can take some time, don't go to the next step until you check that certificates have been indeed created. If you find two files under the agents folder and one pfx file inside the users folder, you're good to go.
+The generation of certificates can take some time, don't stop the containers or go to the next step until you check that
+certificates have been indeed created. This should be automatically done when the `... compose up ...` command finishes.
+If you find two files under the agents folder and one pfx file inside the users folder, you're good to go.
 :::
 
-Now, it's time to start OpenUEM's components
-
-```(bash)
-docker compose --profile openuem up -d --build
-```
-
-We should see that all components have started:
-
-```
- ✔ Volume "openuem_jetstream" Created
- ✔ Container openuem-ocsp-responder-1 Started
- ✔ Container openuem-nats-server Started
- ✔ Container openuem-console-1 Started
- ✔ Container openuem-notification-worker-1 Started
- ✔ Container openuem-cert-manager-worker-1 Started
- ✔ Container openuem-agents-worker-1 Started
-```
-
-If you want to use Caddy as a reverse proxy:
-
-```
-docker compose --profile caddy up -d
-```
-
-The Caddy container should be created and started:
-
-```
- ✔ Container openuem-caddy-1  Started
-```
-
-If we want to stop OpenUEM we should run the following commands:
-
-```(bash)
-docker compose --profile openuem down
-docker compose --profile init down
-```
-
-If you're using the Caddy option you can stop it with:
-
-```(bash)
-docker compose --profile caddy down
-```
-
 :::warning
-If you find any error trying to launch the services, run the docker compose down commands shown above, **remove the volumes and the certificates folder** and start again
+If you find any error trying to launch the services, run the docker compose down commands shown below, **remove the
+volumes and the certificates folder** and start again
 
-```
-docker compose --profile openuem down
-docker compose --profile init down
+If you don't use Caddy:
+```bash
+docker compose down
 sudo rm -rf certificates
-docker volume rm openuem_jetstream
-docker volume rm openuem_pgdata
+docker volume rm openuem_jetstream openuem_pgdata
 ```
 
-And if you use the Caddy option
-
-```
-docker volume rm openuem_caddy_config
-docker volume rm openuem_caddy_data
+And if you use the Caddy option:
+```bash
+docker compose -f compose-caddy.yml down
+sudo rm -rf certificates
+docker volume rm openuem_jetstream openuem_pgdata openuem_caddy_config openuem_caddy_data
 ```
 
 Open an issue with all the possible information if you can't start OpenUEM with Docker
 :::
 
-## 5. Trust in digital certificates created
 
-Before we can visit OpenUEM's console, we must import two digital certificates to our browser, the Certificate Authority certificate (ca.cer) and the user's certificate to log in. You have a guide explaining how to import certificates [here](/docs/Advanced%20Topics/user-certificate)
+## 5. Stopping OpenUEM
 
-Next to the compose .yaml file you’ll find a **certificates folder** containing all the certificates that OpenUEM has created and that are [required to run](/docs/Introduction/security).
+If we want to stop OpenUEM we should run the following commands:
 
-## 6. Visit OpenUEM's Console
+Without Caddy support:
+```(bash)
+docker compose down
+```
 
-Now open `https://SERVER_NAME:CONSOLE_PORT` (replace the values that you've set in your .env file) and you should see OpenUEM's console
+With Caddy support:
+```(bash)
+docker compose -f compose-caddy.yml down
+```
+
+## 6. Trust in digital certificates created
+
+Before we can visit OpenUEM's console, we must import two digital certificates to our browser, the Certificate Authority
+certificate (ca.cer) and the user's certificate to log in. You have a guide explaining how to import
+certificates [here](/docs/Advanced%20Topics/user-certificate)
+
+Next to the compose .yaml file you’ll find a **certificates folder** containing all the certificates that OpenUEM has
+created and that are [required to run](/docs/Introduction/security).
+
+## 7. Visit OpenUEM's Console
+
+Now open `https://CONSOLE_HOST:CONSOLE_PORT` (replace the values that you've set in your .env file) and you should see
+OpenUEM's console
 
 :::note
-If you've set a reverse proxy the url should be `https://REVERSE_PROXY_SERVER`
+If you've set a reverse proxy the url should be `https://REVERSE_PROXY_HOST:REVERSE_PROXY_CONSOLE_PORT`
 :::
 
 ![Console LogIn](/img/console/login.png)
@@ -235,31 +186,32 @@ If you've set a reverse proxy the url should be `https://REVERSE_PROXY_SERVER`
 Finally, log in user your admin certificate and read how to install and add your first agent.
 
 :::note
-If you see any certificates error, please ensure that you've imported the right certificates in the right certificate stores of your browser
+If you see any certificates error, please ensure that you've imported the right certificates in the right certificate
+stores of your browser
 :::
 
-## 7. Update
+## 8. Update
 
-To update the Docker containers, use docker compose:
-
+To update the Docker containers, use docker compose without the Caddy option:
 ```(bash)
-docker compose pull
-
-docker compose --profile openuem up --force-recreate -d --build
+docker compose up --force-recreate -d --build --pull
 ```
 
-And if you use the Caddy option
+And if you use the Caddy option:
 
 ```(bash)
-docker compose --profile caddy up --force-recreate -d
+docker compose up --force-recreate -d  --pull
 ```
 
-## 8. Troubleshooting and FAQ
+## 9. Troubleshooting and FAQ
 
-### 8.1 Why I get 401 | Please provide valid credentials when I try to log into OpenUEM console?
+### 9.1. Why I get 401 | Please provide valid credentials when I try to log into OpenUEM console?
 
-OpenUEM requires a user's certificate to log in. That certificate must be imported in the user's browser before trying to log-in. You can import the certificates following [these steps](/docs/Advanced%20Topics/user-certificate)
+OpenUEM requires a user's certificate to log in. That certificate must be imported in the user's browser before trying
+to log-in. You can import the certificates following [these steps](/docs/Advanced%20Topics/user-certificate)
 
-### 8.2 Why I see messages like _read certificates/console.cer: is a directory_ in docker logs?
+### 9.2. Why I see messages like _read certificates/console.cer: is a directory_ in docker logs?
 
-That means that certificates were not generated in the initial phase, most probably there's a connection issue with the database container or wrong credentials have been used. Database credentials must match between the DATABASE_URL variable set in the .env file and the file build/postgres/init.sh file.
+That means that certificates were not generated in the initial phase, most probably there's a connection issue with the
+database container or wrong credentials have been used. Database credentials must match between the DATABASE_URL
+variable set in the .env file and the file build/postgres/init.sh file.

--- a/docs/02-Installation/01-Server/04-docker.md
+++ b/docs/02-Installation/01-Server/04-docker.md
@@ -1,6 +1,6 @@
 ---
-title: 🐳 Docker
-description: How to deploy OpenUEM server components using Docker
+title: 🐳 Docker / Podman
+description: How to deploy OpenUEM server components using Docker / Podman
 keywords:
   [
     IT assets,
@@ -11,19 +11,21 @@ keywords:
     unified endpoint manager,
     remote monitoring and management,
     docker,
+    podman,
   ]
 ---
 
-# 🐳 Docker
+# 🐳 Docker / Podman
 
-OpenUEM can be tested using Docker containers that are hosted in [Docker Hub](https://hub.docker.com/u/openuem)
+OpenUEM can be run using Docker/Podman containers that are hosted on [Docker Hub](https://hub.docker.com/u/openuem)
 
-You can use [docker compose](https://docs.docker.com/compose/) to install all OpenUEM components in a single machine
-following these steps:
+You can use [docker compose](https://docs.docker.com/compose/)
+or [podman compose](https://github.com/containers/podman-compose) to install and run all OpenUEM components on a single
+machine following these steps:
 
-## 1. Get the docker-compose file
+## 1. Get the compose file
 
-Clone the openuem-docker repository:
+Clone the `openuem-docker` repository:
 
 ```(bash)
 git clone https://github.com/open-uem/openuem-docker
@@ -34,15 +36,14 @@ git clone https://github.com/open-uem/openuem-docker
 Use the file named `.env-example` file to create a `.env` file
 
 :::note
-The file must be named .env without extension and with a dot before the env word as required by Docker to read the
+The file must be named `.env` without extension and with a dot before the env word as required by Docker to read the
 environment variables
 :::
 
 In the `.env` file, edit the environment variables that docker compose will use to build and get the containers up and
 running. The `.env-example` you just copied already sets up a working demo instance of OpenUEM on the `openuem.example`
-domain. If you
-want to simply try out OpenUEM you can just use it as-is. If you want to setup a production system or use your own
-domain and information, you can customize the `.env` just created.
+domain. If you want to simply try out OpenUEM you can just use it as-is. If you want to setup a production system or use
+your own domain and information, you can customize the `.env` you just created.
 
 :::danger
 It's strongly recommended to change the JWT key with a random 32 characters long string
@@ -86,7 +87,7 @@ DNS, you can override your devices `hosts` configuration and allow local domain 
 - On Windows: the configuration can be found under `C:\Windows\System32\drivers\etc\hosts`. Add the line
   `{YOUR_LOCAL_IP} *.{OPENUEM_DOMAIN}`
 
-You have to replace `{YOUR_LOCAL_IP}` and `{OPENUEM_DOMAIN}` with their respective values. It is **important** that you
+You have to replace `{YOUR_LOCAL_IP}` and `{OPENUEM_DOMAIN}` with their respective values set in the `.env` file. It is **important** that you
 use your **local ip address** (e.g. 192.168.1.43) **instead** of localhost or 127.0.0.1. Docker will copy these
 overrides into the containers on start. If you use localhost, each container will only try to connect to itself, making
 proper domain resolution impossible.
@@ -103,17 +104,19 @@ table above). Remember that the hosts / domains you set have to be resolvable by
 
 ## 4. Launch docker compose command
 
-Where the compose.yaml file and the .env files are located, launch OpenUEM with the following commands:
+Where the `compose.yaml` file and the .env files are located, launch OpenUEM with the following commands:
 
 Without Caddy support:
 
 ```bash
-docker compose -d --build
+# Docker Compose:
+docker compose up -d --build 
 ```
 
 With Caddy support:
 
-```(bash)
+```bash
+# Docker Compose:
 docker compose -f compose-caddy.yml up -d --build
 ```
 
@@ -124,14 +127,13 @@ On first start all the certificates are generated in the certificates folder:
 :::warning
 The generation of certificates can take some time, don't stop the containers or go to the next step until you check that
 certificates have been indeed created. This should be automatically done when the `... compose up ...` command finishes.
-If you find two files under the agents folder and one pfx file inside the users folder, you're good to go.
-:::
-
-:::warning
-If you find any error trying to launch the services, run the docker compose down commands shown below, **remove the
+If you find two files under the `agents` folder and one `.pfx` file inside the `users` folder, you're good to go.
+ 
+If you find any error trying to launch the services, run the `docker compose down` or `podman compose down` commands shown below, **remove the
 volumes and the certificates folder** and start again
 
 If you don't use Caddy:
+
 ```bash
 docker compose down
 sudo rm -rf certificates
@@ -139,6 +141,7 @@ docker volume rm openuem_jetstream openuem_pgdata
 ```
 
 And if you use the Caddy option:
+
 ```bash
 docker compose -f compose-caddy.yml down
 sudo rm -rf certificates
@@ -148,17 +151,18 @@ docker volume rm openuem_jetstream openuem_pgdata openuem_caddy_config openuem_c
 Open an issue with all the possible information if you can't start OpenUEM with Docker
 :::
 
-
 ## 5. Stopping OpenUEM
 
 If we want to stop OpenUEM we should run the following commands:
 
 Without Caddy support:
+
 ```(bash)
 docker compose down
 ```
 
 With Caddy support:
+
 ```(bash)
 docker compose -f compose-caddy.yml down
 ```
@@ -166,10 +170,10 @@ docker compose -f compose-caddy.yml down
 ## 6. Trust in digital certificates created
 
 Before we can visit OpenUEM's console, we must import two digital certificates to our browser, the Certificate Authority
-certificate (ca.cer) and the user's certificate to log in. You have a guide explaining how to import
+certificate (`ca.cer`) and the user's certificate to log in. You have a guide explaining how to import
 certificates [here](/docs/Advanced%20Topics/user-certificate)
 
-Next to the compose .yaml file you’ll find a **certificates folder** containing all the certificates that OpenUEM has
+Next to the `compose.yaml` file you’ll find a **certificates folder** containing all the certificates that OpenUEM has
 created and that are [required to run](/docs/Introduction/security).
 
 ## 7. Visit OpenUEM's Console
@@ -193,6 +197,7 @@ stores of your browser
 ## 8. Update
 
 To update the Docker containers, use docker compose without the Caddy option:
+
 ```(bash)
 docker compose up --force-recreate -d --build --pull
 ```
@@ -213,5 +218,5 @@ to log-in. You can import the certificates following [these steps](/docs/Advance
 ### 9.2. Why I see messages like _read certificates/console.cer: is a directory_ in docker logs?
 
 That means that certificates were not generated in the initial phase, most probably there's a connection issue with the
-database container or wrong credentials have been used. Database credentials must match between the DATABASE_URL
-variable set in the .env file and the file build/postgres/init.sh file.
+database container or wrong credentials have been used. Database credentials must match between the `DATABASE_URL`
+variable set in the `.env` file and the file `build/postgres/init.sh` file.


### PR DESCRIPTION
In conjunction with https://github.com/open-uem/openuem-docker/pull/4 this PR updates the docker documentation to reflect the new compose setup and environment variables. Besides that, some wording was improved and podman mentioned as another method to run the OCI containers using the compose setup.

This PR should be merged in conjunction with https://github.com/open-uem/openuem-docker/pull/4.